### PR TITLE
feat: add command to import data from CSV files

### DIFF
--- a/app/Console/Commands/Imports/Orders/ImportOrderItems.php
+++ b/app/Console/Commands/Imports/Orders/ImportOrderItems.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Console\Commands\Imports\Orders;
+
+use League\Csv\Reader;
+use App\Models\Orders\Order;
+use Illuminate\Console\Command;
+use App\Models\Products\ProductVariant;
+
+class ImportOrderItems extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'import:order-items {file}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Import order items from a CSV file using league/csv';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $file = $this->argument('file');
+
+        if (!file_exists($file)) {
+            $this->error("File not found: $file");
+            return Command::FAILURE;
+        }
+
+        $csv = Reader::createFromPath($file, 'r');
+        $csv->setHeaderOffset(0); // Use the first row as headers
+
+        foreach ($csv->getRecords() as $row) {
+            $externalOrderId = trim($row['order_id']);
+            $variantId = trim($row['pizza_id']);
+            $qty = (int) $row['quantity'];
+
+            // Lookup order and variant
+            $order = Order::where('reference_id', $externalOrderId)->first();
+            $variant = ProductVariant::where('product_variant_id', $variantId)->first();
+
+            if (!$order) {
+                $this->warn("Order [$externalOrderId] not found. Skipping.");
+                continue;
+            }
+
+            if (!$variant) {
+                $this->warn("Product variant [$variantId] not found. Skipping.");
+                continue;
+            }
+
+            $order->productVariants()->attach($variant->product_variant_id, ['quantity' => $qty]);
+
+            $this->info("✅ Imported: Order {$externalOrderId} → {$variantId} x {$qty}");
+        }
+
+        $this->info("🎉 Done importing order items.");
+        return Command::SUCCESS;
+    }
+}

--- a/app/Console/Commands/Imports/Orders/ImportOrders.php
+++ b/app/Console/Commands/Imports/Orders/ImportOrders.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Console\Commands\Imports\Orders;
+
+use League\Csv\Reader;
+use App\Models\Orders\Order;
+use Illuminate\Support\Carbon;
+use Illuminate\Console\Command;
+
+class ImportOrders extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'import:orders {file}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Import orders from a CSV file using league/csv';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $file = $this->argument('file');
+
+        if (!file_exists($file)) {
+            $this->error("File not found: $file");
+            return Command::FAILURE;
+        }
+
+        $csv = Reader::createFromPath($file, 'r');
+        $csv->setHeaderOffset(0); // Use first row as header
+
+        foreach ($csv->getRecords() as $row) {
+
+            $externalId = trim($row['order_id']);
+            $date = trim($row['date']);
+            $time = trim($row['time']);
+
+            $datetime = Carbon::parse("$date $time");
+
+            Order::updateOrCreate([
+                'reference_id' => $externalId,
+            ], [
+                'order_at' => $datetime,
+            ]);
+
+            $this->info("✅ Imported order [$externalId] at $datetime");
+        }
+
+        $this->info("🎉 Done importing orders.");
+        return Command::SUCCESS;
+    }
+}

--- a/app/Console/Commands/Imports/Products/ImportProductVariants.php
+++ b/app/Console/Commands/Imports/Products/ImportProductVariants.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Console\Commands\Imports\Products;
+
+use League\Csv\Reader;
+use App\Models\Products\Product;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use App\Models\Variants\VariantLabel;
+
+class ImportProductVariants extends Command
+{
+    protected $signature = 'import:product-variants {file}';
+    protected $description = 'Import product variants from a CSV file using league/csv';
+
+    public function handle()
+    {
+        $path = $this->argument('file');
+
+        if (!file_exists($path)) {
+            $this->error("File not found at: $path");
+            return Command::FAILURE;
+        }
+
+        try {
+            $csv = Reader::createFromPath($path, 'r');
+            $csv->setHeaderOffset(0); // First row is the header
+
+            DB::beginTransaction();
+
+            foreach ($csv->getRecords() as $row) {
+                $variantId = trim($row['pizza_id']);
+                $productId = trim($row['pizza_type_id']);
+                $sizeLabel = trim($row['size']);
+                $price     = trim($row['price']);
+
+                $product = Product::where('product_id', $productId)->first();
+
+                if (!$product) {
+                    $this->warn("Product not found for code: [$productId]. Skipping.");
+                    continue;
+                }
+
+                $label = VariantLabel::firstOrCreate([
+                    'label' => $sizeLabel,
+                ]);
+
+                $product->variants()->updateOrCreate([
+                    'product_variant_id' => $variantId,
+                ],[
+                    'variant_label_id' => $label->id,
+                    'price' => $price,
+                ]);
+
+                $this->info("✅ Imported variant: $variantId → Product: $productId | Size: $sizeLabel | ₱$price");
+            }
+
+            DB::commit();
+            $this->info("🎉 Variant import completed successfully.");
+            return Command::SUCCESS;
+        } catch (\Exception $e) {
+            DB::rollBack();
+            $this->error("🚫 Import failed: " . $e->getMessage());
+            return Command::FAILURE;
+        }
+    }
+}

--- a/app/Console/Commands/Imports/Products/ImportProducts.php
+++ b/app/Console/Commands/Imports/Products/ImportProducts.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Console\Commands\Imports\Products;
+
+use League\Csv\Reader;
+use Illuminate\Console\Command;
+use App\Models\Categories\Category;
+use App\Models\Ingredients\Ingredient;
+
+class ImportProducts extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'import:products {file}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Import products and ingredients from CSV file';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $path = $this->argument('file');
+        $csv = Reader::createFromPath($path, 'r');
+        $csv->setHeaderOffset(0); // first row as headers
+
+        foreach ($csv as $row) {
+
+            $category = Category::firstOrCreate([
+                'name' => trim($row['category']),
+            ]);
+
+            $product = $category->products()->create([
+                'product_id' => $row['pizza_type_id'],
+                'name' => $this->cleanText(trim($row['name'])),
+            ]);
+
+            $ingredients = array_map('trim', explode(',', $row['ingredients']));
+
+            foreach ($ingredients as $ingredientName) {
+                $ingredient = Ingredient::firstOrCreate(['name' => $this->cleanText(trim($ingredientName))]);
+
+                $ingredient->products()->attach($product->product_id);
+            }
+
+            $this->info("Imported: " . $product->name);
+        }
+
+        $this->info("Import complete.");
+    }
+
+    private function cleanText($text)
+    {
+        $replace = [
+            "\x91" => "'", // Left single quote
+            "\x92" => "'", // Right single quote
+            "\x93" => '"', // Left double quote
+            "\x94" => '"', // Right double quote
+            "\x96" => '-', // En dash
+            "\x97" => '-', // Em dash
+            "\x85" => '...', // Ellipsis
+            "\xA0" => ' ', // Non-breaking space
+            "\xC2\xA0" => ' ', // Non-breaking space (UTF-8)
+            "\u{2018}" => "'", // Unicode curly left quote
+            "\u{2019}" => "'", // Unicode curly right quote
+        ];
+        return strtr($text, $replace);
+    }
+}


### PR DESCRIPTION
# CSV Import Functionality

## Summary
Implements CSV import for core business data (products, variants, ingredients, orders) including:
- New `import` Artisan command
  - php artisan import:products {file}
  - php artisan import:product-variants {file}
  - php artisan import:orders {file}
  - php artisan import:order-items {file}
- Reusable import service using league/csv
- Database migrations with proper relationships

## Supported Files
- `pizza_types.csv` - Product definitions
- `product_variants.csv` - Size/variant options  
- `orders.csv` - Order headers
- `order_items.csv` - Line items