### PR TITLE
feat: implement sales analytics API with controller, service, reposit…

### DIFF
--- a/app/Http/Controllers/Sales/SalesController.php
+++ b/app/Http/Controllers/Sales/SalesController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers\Sales;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use App\Services\Sales\SalesService;
+
+class SalesController extends Controller
+{
+
+    protected $salesService;
+
+    public function __construct(SalesService $salesService)
+    {
+        $this->salesService = $salesService;
+    }
+
+    public function summary()
+    {
+        $summary = $this->salesService->getSummary();
+
+        return response()->json($summary);
+    }
+
+    public function topProducts(Request $request)
+    {
+        $variants = $this->salesService->getTopSellingProducts($request->limit);
+
+        return response()->json($variants);
+    }
+
+    public function topVariants(Request $request)
+    {
+        $variants = $this->salesService->getTopSellingVariants($request->limit);
+        return response()->json($variants);
+    }
+
+    public function revenueOverTime(Request $request)
+    {
+        $revenueOverTime = $this->salesService->getRevenueOverTime($request->limit);
+        return response()->json($revenueOverTime);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use App\Repositories\Eloquent\Sales\SalesRepository;
+use App\Repositories\Contracts\Sales\SalesRepositoryInterface;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -11,7 +13,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->bind(SalesRepositoryInterface::class, SalesRepository::class);
     }
 
     /**

--- a/app/Repositories/Contracts/Sales/SalesRepositoryInterface.php
+++ b/app/Repositories/Contracts/Sales/SalesRepositoryInterface.php
@@ -1,0 +1,14 @@
+<?php
+namespace App\Repositories\Contracts\Sales;
+
+use Illuminate\Support\Collection;
+
+interface SalesRepositoryInterface
+{
+    public function getRevenueOverTime(int $limit): Collection;
+    public function getTopSellingProducts(int $limit): Collection;
+    public function getTopSellingVariants(int $limit): Collection;
+    public function getSalesWithVariants(): Collection;
+    public function getTotalSalesCount(): int;
+    public function getTotalRevenue(): float;
+}

--- a/app/Repositories/Eloquent/Sales/SalesRepository.php
+++ b/app/Repositories/Eloquent/Sales/SalesRepository.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Repositories\Eloquent\Sales;
+
+use App\Models\Orders\Order;
+use App\Models\Products\Product;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use App\Models\Products\ProductVariant;
+use App\Repositories\Contracts\Sales\SalesRepositoryInterface;
+
+class SalesRepository implements SalesRepositoryInterface
+{
+    public function getRevenueOverTime(int $limit): Collection
+    {
+        return DB::table('order_items')
+            ->join('product_variants', 'order_items.product_variant_id', '=', 'product_variants.product_variant_id')
+            ->join('orders', 'order_items.reference_id', '=', 'orders.reference_id')
+            ->selectRaw('DATE(orders.order_at) as date')
+            ->selectRaw('SUM(order_items.quantity * product_variants.price) as total_revenue')
+            ->groupBy('date')
+            ->orderByDesc('date')
+            ->limit($limit)
+            ->get()->sortBy('date')->values();
+    }
+
+    public function getTopSellingProducts(int $limit): Collection
+    {
+        return Product::select('products.product_id', 'products.name')
+            ->join('product_variants', 'products.product_id', '=', 'product_variants.product_id')
+            ->join('order_items', 'product_variants.product_variant_id', '=', 'order_items.product_variant_id')
+            ->selectRaw('SUM(order_items.quantity) as quantity_sold')
+            ->selectRaw('SUM(order_items.quantity * product_variants.price) as total_sales')
+            ->groupBy('products.product_id', 'products.name')
+            ->orderByDesc('quantity_sold')
+            ->limit($limit)
+            ->get();
+    }
+
+    public function getTopSellingVariants(int $limit): Collection
+    {
+        return  ProductVariant::with(['product', 'variantLabel'])
+            ->withSum('orders as total_quantity', 'order_items.quantity') // alias pivot sum
+            ->orderByDesc('total_quantity')
+            ->limit($limit)
+            ->get();
+    }
+
+    public function getSalesWithVariants(): Collection
+    {
+        return Order::with([
+            'productVariants.variantLabel',
+            'productVariants.product.category'
+        ])->get();
+    }
+
+    public function getTotalSalesCount(): int
+    {
+        return Order::count();
+    }
+
+    public function getTotalRevenue(): float
+    {
+        return Order::with('productVariants')->get()
+            ->sum(function ($sale) {
+                return $sale->productVariants->sum(function ($variant) {
+                    return $variant->price * $variant->pivot->quantity;
+                });
+            });
+    }
+}

--- a/app/Services/Sales/SalesService.php
+++ b/app/Services/Sales/SalesService.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Services\Sales;
+
+use Illuminate\Support\Collection;
+use App\Repositories\Contracts\Sales\SalesRepositoryInterface;
+
+class SalesService
+{
+    protected $salesRepository;
+
+    public function __construct(SalesRepositoryInterface $salesRepository)
+    {
+        $this->salesRepository = $salesRepository;
+    }
+
+    public function getSummary(): array
+    {
+        $sales = $this->salesRepository->getSalesWithVariants();
+        $variantSales = $this->calculateVariantSales($sales);
+
+        return [
+            'total_sales' => $this->salesRepository->getTotalSalesCount(),
+            'total_revenue' => $this->salesRepository->getTotalRevenue(),
+            'average_sale_value' => $this->calculateAverageSaleValue(),
+            'most_popular_variant' => $this->getMostPopularVariant($variantSales),
+            'top_category' => $this->getTopCategory($variantSales),
+        ];
+    }
+
+    public function getRevenueOverTime(int $limit): Collection
+    {
+        return $this->salesRepository->getRevenueOverTime($limit);
+    }
+
+    public function getTopSellingProducts(int $limit): Collection
+    {
+        return $this->salesRepository->getTopSellingProducts($limit);
+    }
+
+    public function getTopSellingVariants(int $limit): Collection
+    {
+        return $this->salesRepository->getTopSellingVariants($limit)
+            ->map(function ($variant) {
+                $quantitySold = $variant->orders->sum('pivot.quantity');
+
+                return [
+                    'product_id' => $variant->product->id,
+                    'product_name' => $variant->product->name,
+                    'variant' => $variant->variantLabel?->label, // PHP 8 nullsafe operator
+                    'variant_price' => (float) $variant->price,
+                    'quantity_sold' => $quantitySold,
+                    'total_sales' => (float) $variant->price * $quantitySold,
+                ];
+            });
+    }
+
+    protected function calculateVariantSales($sales): array
+    {
+        $variantSales = [];
+
+        foreach ($sales as $sale) {
+            foreach ($sale->productVariants as $variant) {
+                $variantId = $variant->id;
+
+                if (!isset($variantSales[$variantId])) {
+                    $variantSales[$variantId] = [
+                        'variant' => $variant,
+                        'quantity' => 0
+                    ];
+                }
+
+                $variantSales[$variantId]['quantity'] += $variant->pivot->quantity;
+            }
+        }
+
+        return $variantSales;
+    }
+
+    protected function calculateAverageSaleValue(): float
+    {
+        $totalSales = $this->salesRepository->getTotalSalesCount();
+        return $totalSales > 0
+            ? round($this->salesRepository->getTotalRevenue() / $totalSales, 2)
+            : 0;
+    }
+
+    protected function getMostPopularVariant(array $variantSales): ?array
+    {
+        return collect($variantSales)
+            ->sortByDesc('quantity')
+            ->first();
+    }
+
+    protected function getTopCategory(array $variantSales): string
+    {
+        $categoryCounts = [];
+
+        foreach ($variantSales as $sale) {
+            $category = $sale['variant']->product->category->name ?? 'Unknown';
+            $categoryCounts[$category] = ($categoryCounts[$category] ?? 0) + $sale['quantity'];
+        }
+
+        arsort($categoryCounts);
+
+        return array_key_first($categoryCounts) ?? 'Unknown';
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Sales\SalesController;
 use App\Http\Controllers\Orders\OrderController;
 use App\Http\Controllers\Products\ProductController;
 
@@ -22,4 +23,10 @@ Route::prefix('v1')->group(function () {
         Route::get('{product_id}', [ProductController::class, 'show']);
     });
 
+    Route::prefix('sales')->group(function () {
+        Route::get('summary', [SalesController::class, 'summary']);
+        Route::get('top-products', [SalesController::class, 'topProducts']);
+        Route::get('top-variants', [SalesController::class, 'topVariants']);
+        Route::get('revenue-over-time', [SalesController::class, 'revenueOverTime']);
+    });
 });


### PR DESCRIPTION
## Summary
This pull request introduces the Sales Analytics API, including:
- `SalesController`
- `SalesRepositoryInterface` & `SalesRepository`
- `SalesService`
- `SalesServiceProvider` for binding
- API routes under `/api/v1/sales`

## Features
- `/api/v1/sales/summary`: Summary stats like total sales, revenue, average sale value, top category
- `/api/v1/sales/top-products`: Top-selling products by quantity
- `/api/v1/sales/top-variants`: Top-selling variants
- `/api/v1/sales/revenue-over-time`: Revenue trend over the last N days

## Implementation Details
- Applied the repository-service pattern for separation of concerns
- Used Eloquent relationships to calculate totals and aggregates efficiently
- Registered bindings in `AppServiceProvider` for dependency injection

## Notes
- You can modify the `limit` in each endpoint via query params (e.g., `?limit=5`)
- Ensure `.env` has `DEFAULT_PER_PAGE` set if you’re using the helper for pagination