### PR TITLE
feat: implement Laravel Sanctum authentication (login, register, logo…

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use App\Models\User;
+
+class AuthController extends Controller
+{
+    public function login(Request $request)
+    {
+        $request->validate([
+            'email'    => 'required|email',
+            'password' => 'required',
+        ]);
+
+        $user = User::where('email', $request->email)->first();
+
+        if (!$user || !Hash::check($request->password, $user->password)) {
+            return response()->json(['message' => 'Invalid credentials'], 401);
+        }
+
+        $token = $user->createToken('api-token')->plainTextToken;
+
+        return response()->json([
+            'access_token' => $token,
+            'token_type' => 'Bearer',
+            'user' => $user,
+        ]);
+    }
+
+    public function logout(Request $request)
+    {
+        $request->user()->currentAccessToken()->delete();
+
+        return response()->json(['message' => 'Logged out successfully']);
+    }
+
+    public function me(Request $request)
+    {
+        return response()->json($request->user());
+    }
+
+    public function register(Request $request)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|string|email|unique:users,email',
+            'password' => 'required|string|min:8|confirmed',
+        ]);
+
+        $user = User::create([
+            'name' => $request->name,
+            'email' => $request->email,
+            'password' => bcrypt($request->password),
+        ]);
+
+        $token = $user->createToken('api-token')->plainTextToken;
+
+        return response()->json([
+            'access_token' => $token,
+            'token_type' => 'Bearer',
+            'user' => $user,
+        ], 201);
+    }
+}

--- a/app/Http/Controllers/Orders/OrderController.php
+++ b/app/Http/Controllers/Orders/OrderController.php
@@ -8,7 +8,6 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\Orders\OrderListResource;
 use App\Http\Resources\Orders\OrderDetailResource;
 
-
 class OrderController extends Controller
 {
     public function index(Request $request)

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,11 +6,12 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, Notifiable, HasApiTokens;
 
     /**
      * The attributes that are mass assignable.

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,6 +18,7 @@ class DatabaseSeeder extends Seeder
         User::factory()->create([
             'name' => 'Test User',
             'email' => 'test@example.com',
+            'password' => bcrypt('password'),
         ]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,15 +2,22 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Auth\AuthController;
 use App\Http\Controllers\Sales\SalesController;
 use App\Http\Controllers\Orders\OrderController;
 use App\Http\Controllers\Products\ProductController;
 
-Route::get('/user', function (Request $request) {
-    return $request->user();
-})->middleware('auth:sanctum');
+Route::prefix('v1')->middleware('auth:sanctum')->group(function () {
 
-Route::prefix('v1')->group(function () {
+    Route::prefix('auth')->group(function () {
+        Route::withoutMiddleware('auth:sanctum')->group(function () {
+            Route::post('login', [AuthController::class, 'login']);
+            Route::post('register', [AuthController::class, 'register']);
+        });
+
+        Route::get('me', [AuthController::class, 'me']);
+        Route::post('logout', [AuthController::class, 'logout']);
+    });
 
     Route::prefix('orders')->group(function () {
         Route::get('', [OrderController::class, 'index']);


### PR DESCRIPTION
## Summary

This pull request implements authentication functionality using **Laravel Sanctum**. It includes user login, registration, logout, and authenticated user profile retrieval (`/me`).

## Features

- `POST /api/v1/auth/login` - Login with email and password
- `POST /api/v1/auth/register` - Register new users
- `POST /api/v1/auth/logout` - Logout the authenticated user
- `GET /api/v1/auth/me` - Get the authenticated user’s data

## Backend Implementation

- Added Sanctum setup and middleware configuration
- Created `AuthController` for authentication endpoints
- Used `HasApiTokens` trait and `auth:sanctum` middleware
- Added form request validation for login and register